### PR TITLE
Plan google calendar integration for event timeslots

### DIFF
--- a/frontend/src/services/realApi.ts
+++ b/frontend/src/services/realApi.ts
@@ -1,4 +1,5 @@
 import { APIConfig, APIError, ApiEvent, ApiConfirmation, ApiJoinRequest, ApiLocation, ListEventsResponse, CreateEventResponse, GetEventResponse, ConfirmEventResponse, JoinRequestResponse, ListLocationsResponse, CreateEventRequest, ConfirmEventRequest, JoinEventRequest, UpdateProfileRequest, GetUserProfileResponse, CreateUserProfileRequest, CreateUserProfileResponse, UpdateUserProfileRequest, UpdateUserProfileResponse } from '../types/api';
+import { CalendarBusyInterval, CalendarIntegrationStatus } from '../types/api';
 
 // Debug information interface
 interface DebugInfo {
@@ -264,6 +265,27 @@ export class RealAPIClient {
     await this.fetch(`/api/events/public/${eventId}/joins/${joinRequestId}`, {
       method: 'DELETE'
     });
+  }
+
+  // --- Calendar integration (Google) ---
+  async getCalendarIntegrationStatus(): Promise<CalendarIntegrationStatus> {
+    return await this.fetch<CalendarIntegrationStatus>('/api/integrations/google/status');
+  }
+
+  async getGoogleFreeBusy(timeMinUtcIso: string, timeMaxUtcIso: string): Promise<{ busy: CalendarBusyInterval[] }> {
+    return await this.fetch<{ busy: CalendarBusyInterval[] }>(`/api/integrations/google/freebusy?timeMin=${encodeURIComponent(timeMinUtcIso)}&timeMax=${encodeURIComponent(timeMaxUtcIso)}`);
+  }
+
+  async getGoogleAuthUrl(redirectUri?: string): Promise<{ url: string }> {
+    const payload = redirectUri ? { redirectUri } : {};
+    return await this.fetch<{ url: string }>(`/api/integrations/google/auth-url`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async disconnectGoogleCalendar(): Promise<void> {
+    await this.fetch(`/api/integrations/google/disconnect`, { method: 'POST' });
   }
 
   async reportError(error: Error, extraInfo?: {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -54,6 +54,18 @@ export interface UpdateProfileRequest {
   preferredCity: string;
 }
 
+// New: Calendar integration types
+export interface CalendarBusyInterval {
+  start: string; // UTC ISO start
+  end: string;   // UTC ISO end
+}
+
+export interface CalendarIntegrationStatus {
+  provider: 'google';
+  connected: boolean;
+  email?: string;
+}
+
 export interface APIClient {
   // Event endpoints
   createEvent(request: CreateEventRequest): Promise<ApiEvent>;
@@ -90,4 +102,10 @@ export interface APIClient {
   
   // Legacy profile methods for backward compatibility
   updateProfile(request: UpdateProfileRequest): Promise<void>;
+
+  // Calendar integration (Google)
+  getCalendarIntegrationStatus(): Promise<CalendarIntegrationStatus>;
+  getGoogleFreeBusy(timeMinUtcIso: string, timeMaxUtcIso: string): Promise<{ busy: CalendarBusyInterval[] }>;
+  getGoogleAuthUrl(redirectUri?: string): Promise<{ url: string }>;
+  disconnectGoogleCalendar(): Promise<void>;
 }


### PR DESCRIPTION
Add Google Calendar integration to display blocked time slots in the event creation calendar.

---
<a href="https://cursor.com/background-agent?bcId=bc-69c0e88f-065a-4e97-9cc4-8521e3c64419">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-69c0e88f-065a-4e97-9cc4-8521e3c64419">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

