### PR TITLE
Localize frontend dates and timestamps

### DIFF
--- a/frontend/src/components/ConfirmEventModal.tsx
+++ b/frontend/src/components/ConfirmEventModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Modal, Button, Form, Alert } from 'react-bootstrap';
 import { useAPI } from '../services/apiProvider';
 import { components } from '../types/schema';
-import { formatTimeSlot } from '../utils/dateUtils';
+import { formatTimeSlotLocalized } from '../utils/i18nDateUtils';
 import UserDisplay from './UserDisplay';
 import { BADGE_STYLES } from '../styles/badgeStyles';
 
@@ -490,7 +490,7 @@ export const ConfirmEventModal: React.FC<Props> = ({
                               ? 'var(--tennis-white)' 
                               : 'var(--tennis-navy)' 
                           }}></i>
-                          {formatTimeSlot(timeSlot)}
+                          {formatTimeSlotLocalized(timeSlot)}
                         </div>
                       ))}
                     </div>

--- a/frontend/src/components/event/DefaultEventBody.tsx
+++ b/frontend/src/components/event/DefaultEventBody.tsx
@@ -11,6 +11,7 @@ import TimeAgo from 'react-timeago';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { BADGE_STYLES } from '../../styles/badgeStyles';
 import { useTranslation } from 'react-i18next';
+import { formatTimeSlotLocalized } from '../../utils/i18nDateUtils';
 
 type ApiEvent = components['schemas']['ApiEvent'];
 
@@ -113,7 +114,7 @@ const DefaultEventBody: React.FC<DefaultEventBodyProps> = ({
                       )}
                     </td>
                     <td>{(jr.locations || []).join(', ')}</td>
-                    <td>{(jr.timeSlots || []).map(ts => moment(ts).format('MMM D, LT')).join(', ')}</td>
+                    <td>{(jr.timeSlots || []).map(ts => formatTimeSlotLocalized(ts)).join(', ')}</td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/src/components/event/EventHeader.tsx
+++ b/frontend/src/components/event/EventHeader.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { ActionButton, StyleProps } from './types';
-import moment from 'moment';
 import { components } from '../../types/schema';
 import { formatDuration } from '../../utils/dateUtils';
+import { formatTimeSlotLocalized } from '../../utils/i18nDateUtils';
 import { LocationBadge } from './EventBadges';
 import { BADGE_STYLES, NESTED_BADGE_STYLES } from '../../styles/badgeStyles';
 import { useTranslation } from 'react-i18next';
@@ -21,7 +21,7 @@ interface EventHeaderProps extends StyleProps {
 }
 
 const formatConfirmedDateTime = (datetime: string): string => {
-  return moment(datetime).format('ddd, MMM D @ LT');
+  return formatTimeSlotLocalized(datetime);
 };
 
 // Get status badge info based on event status

--- a/frontend/src/components/event/TimeSlotLabels.tsx
+++ b/frontend/src/components/event/TimeSlotLabels.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TimeSlot } from './types';
-import moment from 'moment';
 import { BADGE_STYLES } from '../../styles/badgeStyles';
+import { formatDateOnlyLocalized, formatTimeOnlyLocalized } from '../../utils/i18nDateUtils';
 
 
 interface Props {
@@ -13,7 +13,7 @@ interface Props {
 const TimeSlotLabels: React.FC<Props> = ({ timeSlots, onSelect, className = '' }) => {
   // Group slots by date using moment
   const groupedSlots = timeSlots.reduce((acc, slot) => {
-    const dateKey = slot.date.format('YYYY-MM-DD');
+    const dateKey = slot.date.toISOString().split('T')[0];
     
     if (!acc[dateKey]) {
       acc[dateKey] = [];
@@ -29,7 +29,7 @@ const TimeSlotLabels: React.FC<Props> = ({ timeSlots, onSelect, className = '' }
           <h6 className="d-flex align-items-center mb-3">
             <i className="bi bi-calendar-event me-2" style={{ color: 'var(--tennis-sage)' }}></i>
             <span style={{ color: 'var(--tennis-navy, #212529)' }}>
-              {moment(dateKey).format('ddd, MMM D')}
+              {formatDateOnlyLocalized(dateKey)}
             </span>
           </h6>
           <div className="d-flex flex-wrap gap-2 ps-4">
@@ -73,7 +73,6 @@ const TimeSlotLabels: React.FC<Props> = ({ timeSlots, onSelect, className = '' }
                 iconColor = 'var(--tennis-navy, #212529)';
               }
 
-              console.log(`Rendering time slot: ${slot.date.format('LT')} - isUserSelected: ${slot.isUserSelected}`);
 
               return (
                 <div
@@ -88,7 +87,7 @@ const TimeSlotLabels: React.FC<Props> = ({ timeSlots, onSelect, className = '' }
                   }}
                 >
                   <i className={`bi bi-clock me-1`} style={{ color: iconColor }}></i>
-                  {slot.date.format('LT')}
+                  {formatTimeOnlyLocalized(slot.date)}
                 </div>
               );
             })}

--- a/frontend/src/utils/i18nDateUtils.ts
+++ b/frontend/src/utils/i18nDateUtils.ts
@@ -63,7 +63,11 @@ export const formatTimeSlotLocalized = (utcTimeSlot: string): string => {
                        i18n.language === 'pl' ? 'pl' : 'en';
   
   // Use current i18n locale for formatting
-  return localDate.locale(currentLocale).format('ddd, MMM D @ LT');
+  localDate.locale(currentLocale);
+  
+  // Use 24-hour format for Polish locale, 12-hour for others
+  const timeFormat = currentLocale === 'pl' ? 'HH:mm' : 'LT';
+  return localDate.format(`ddd, MMM D @ ${timeFormat}`);
 };
 
 /**

--- a/frontend/src/utils/timeSlotCompression.ts
+++ b/frontend/src/utils/timeSlotCompression.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { formatDateTimeRangeLocalized, formatTimeSlotLocalized, formatDateOnlyLocalized, formatMonthDayLocalized } from './i18nDateUtils';
 
 // Interface for time slot - keeping it minimal for utils
 interface TimeSlot {
@@ -59,11 +60,11 @@ const groupConsecutiveSlots = (slots: TimeSlot[]): TimeSlot[][] => {
 };
 
 /**
- * Format a range of consecutive time slots
+ * Format a range of consecutive time slots using localized formatting
  */
 const formatTimeRange = (group: TimeSlot[]): string => {
   if (group.length === 1) {
-    return group[0].date.format('ddd, MMM D • LT');
+    return formatTimeSlotLocalized(group[0].date.toISOString());
   }
   
   const start = group[0];
@@ -72,11 +73,7 @@ const formatTimeRange = (group: TimeSlot[]): string => {
   // Calculate end time by adding 30 minutes to the last slot
   const endTime = end.date.clone().add(30, 'minutes');
   
-  if (start.date.isSame(end.date, 'day')) {
-    return `${start.date.format('ddd, MMM D')} • ${start.date.format('LT')}–${endTime.format('LT')}`;
-  } else {
-    return `${start.date.format('ddd, MMM D • LT')}–${endTime.format('ddd, MMM D • LT')}`;
-  }
+  return formatDateTimeRangeLocalized(start.date, endTime);
 };
 
 /**
@@ -99,8 +96,8 @@ const generalizeToTimeOfDay = (groups: TimeSlot[][], t: TranslationFunction): st
   
   // If spans multiple days and multiple time categories, generalize appropriately
   if (uniqueDates.length > 1 && categoriesArray.length > 1) {
-    const startDate = moment(uniqueDates[0]).format('MMM D');
-    const endDate = moment(uniqueDates[uniqueDates.length - 1]).format('MMM D');
+    const startDate = formatMonthDayLocalized(uniqueDates[0]);
+    const endDate = formatMonthDayLocalized(uniqueDates[uniqueDates.length - 1]);
     
     if (categoriesArray.length >= 3) {
       return `${startDate}–${endDate} • ${t('timeOfDay.wholeDay')}`;
@@ -111,7 +108,7 @@ const generalizeToTimeOfDay = (groups: TimeSlot[][], t: TranslationFunction): st
   
   // If single day but multiple time categories
   if (uniqueDates.length === 1 && categoriesArray.length > 1) {
-    const dateStr = moment(uniqueDates[0]).format('ddd, MMM D');
+    const dateStr = formatDateOnlyLocalized(uniqueDates[0]);
     if (categoriesArray.length >= 3) {
       return `${dateStr} • ${t('timeOfDay.wholeDay')}`;
     } else {
@@ -121,13 +118,13 @@ const generalizeToTimeOfDay = (groups: TimeSlot[][], t: TranslationFunction): st
   
   // If single time category across multiple days
   if (uniqueDates.length > 1 && categoriesArray.length === 1) {
-    const startDate = moment(uniqueDates[0]).format('MMM D');
-    const endDate = moment(uniqueDates[uniqueDates.length - 1]).format('MMM D');
+    const startDate = formatMonthDayLocalized(uniqueDates[0]);
+    const endDate = formatMonthDayLocalized(uniqueDates[uniqueDates.length - 1]);
     return `${startDate}–${endDate} • ${t(`timeOfDay.${categoriesArray[0]}`)}`;
   }
   
   // Default: show first date with time category
-  const firstDate = moment(uniqueDates[0]).format('ddd, MMM D');
+  const firstDate = formatDateOnlyLocalized(uniqueDates[0]);
   return `${firstDate} • ${t(`timeOfDay.${categoriesArray[0]}`)}`;
 };
 
@@ -141,9 +138,9 @@ const generalizeToTimeOfDay = (groups: TimeSlot[][], t: TranslationFunction): st
 export const compressTimeSlots = (timeSlots: TimeSlot[], t: TranslationFunction): string => {
   if (timeSlots.length === 0) return '';
   
-  // For single slot, use original format
+  // For single slot, use localized format
   if (timeSlots.length === 1) {
-    return timeSlots[0].date.format('ddd, MMM D • LT');
+    return formatTimeSlotLocalized(timeSlots[0].date.toISOString());
   }
   
   // Group consecutive time slots


### PR DESCRIPTION
Update `formatTimeSlotLocalized` to use 24-hour format for Polish locale.

This fixes an issue where times were displayed in 12-hour format (e.g., "2pm") instead of 24-hour format (e.g., "14:00") for Polish users, and ensures month names are correctly localized when using this utility.

---
<a href="https://cursor.com/background-agent?bcId=bc-e461266b-c5c5-42cc-84e5-b7776e66a811">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e461266b-c5c5-42cc-84e5-b7776e66a811">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

