### PR TITLE
Translate join event dialog

### DIFF
--- a/frontend/src/components/JoinEventModal.tsx
+++ b/frontend/src/components/JoinEventModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Modal, Button, Form, Alert } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
 import { useAPI, JoinEventRequest, Event } from '../services/apiProvider';
 import TimeSlotLabels from './event/TimeSlotLabels';
 import { EventFlowDiagram } from './EventFlowDiagram';
@@ -28,6 +29,7 @@ export const JoinEventModal: React.FC<Props> = ({
   onHide,
   onJoined
 }) => {
+  const { t } = useTranslation();
   const api = useAPI();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -60,7 +62,7 @@ export const JoinEventModal: React.FC<Props> = ({
           }
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load options');
+        setError(err instanceof Error ? err.message : t('joinModal.failedToLoadOptions'));
       } finally {
         setLoading(false);
       }
@@ -69,7 +71,7 @@ export const JoinEventModal: React.FC<Props> = ({
     if (show) {
       fetchOptions();
     }
-  }, [api, eventId, show]);
+  }, [api, eventId, show, t]);
 
   const handleLocationChange = (locationId: string, checked: boolean) => {
     setSelectedLocations(prev =>
@@ -93,11 +95,11 @@ export const JoinEventModal: React.FC<Props> = ({
       setError(null);
 
       if (selectedLocations.length === 0) {
-        throw new Error('Please select at least one location');
+        throw new Error(t('joinModal.selectLocation'));
       }
 
       if (selectedTimeSlots.length === 0) {
-        throw new Error('Please select at least one time slot');
+        throw new Error(t('joinModal.selectTimeSlot'));
       }
 
       const request: JoinEventRequest = {
@@ -112,7 +114,7 @@ export const JoinEventModal: React.FC<Props> = ({
       onJoined();
       onHide();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to join event');
+      setError(err instanceof Error ? err.message : t('joinModal.failedToJoin'));
     } finally {
       setLoading(false);
     }
@@ -123,7 +125,7 @@ export const JoinEventModal: React.FC<Props> = ({
       <Modal.Header closeButton className="border-0 pb-0">
         <Modal.Title className="fs-4">
           <i className="bi bi-calendar2-check me-2" style={{ color: 'var(--tennis-accent)' }}></i>
-          <span style={{ color: 'var(--tennis-navy)' }}>Join {hostName}'s Game Session</span>
+          <span style={{ color: 'var(--tennis-navy)' }}>{t('joinModal.title', { hostName })}</span>
         </Modal.Title>
       </Modal.Header>
       <Modal.Body className="pt-2">
@@ -147,9 +149,9 @@ export const JoinEventModal: React.FC<Props> = ({
         {loading ? (
           <div className="text-center py-5">
             <div className="spinner-border mb-2" style={{ color: 'var(--tennis-navy)' }} role="status">
-              <span className="visually-hidden">Loading...</span>
+              <span className="visually-hidden">{t('common.loading')}</span>
             </div>
-            <p className="text-muted mb-0">Loading available options...</p>
+            <p className="text-muted mb-0">{t('joinModal.loadingText')}</p>
           </div>
         ) : options ? (
           <Form>
@@ -157,7 +159,7 @@ export const JoinEventModal: React.FC<Props> = ({
               <div className="card-body">
                 <h6 className="card-title d-flex align-items-center mb-3">
                   <i className="bi bi-geo-alt me-2" style={{ color: 'var(--tennis-accent)' }}></i>
-                  <span style={{ color: 'var(--tennis-navy)' }}>Where would you like to play?</span>
+                  <span style={{ color: 'var(--tennis-navy)' }}>{t('joinModal.whereToPlay')}</span>
                 </h6>
                 <div className="ps-2">
                   <div className="d-flex flex-wrap gap-2">
@@ -200,7 +202,7 @@ export const JoinEventModal: React.FC<Props> = ({
                   </div>
                   <small className="text-muted d-block mt-2 ps-2">
                     <i className="bi bi-info-circle me-1"></i>
-                    Select all locations where you can play.
+                    {t('joinModal.locationHelp')}
                   </small>
                 </div>
               </div>
@@ -210,7 +212,7 @@ export const JoinEventModal: React.FC<Props> = ({
               <div className="card-body">
                 <h6 className="card-title d-flex align-items-center mb-3">
                   <i className="bi bi-clock me-2" style={{ color: 'var(--tennis-accent)' }}></i>
-                  <span style={{ color: 'var(--tennis-navy)' }}>When would you like to start?</span>
+                  <span style={{ color: 'var(--tennis-navy)' }}>{t('joinModal.whenToStart')}</span>
                 </h6>
                 <div className="ps-2">
                   <TimeSlotLabels
@@ -223,7 +225,7 @@ export const JoinEventModal: React.FC<Props> = ({
                   />
                   <small className="text-muted d-block mt-2 ps-2">
                     <i className="bi bi-info-circle me-1"></i>
-                    Select all time slots that work for you. {hostName} will choose the final time based on your availability.
+                    {t('joinModal.timeSlotHelp', { hostName })}
                   </small>
                 </div>
               </div>
@@ -239,7 +241,7 @@ export const JoinEventModal: React.FC<Props> = ({
           className="text-decoration-none"
           style={{ color: 'var(--tennis-gray)' }}
         >
-          Cancel
+          {t('common.cancel')}
         </Button>
         <Button
           variant="primary"
@@ -250,12 +252,12 @@ export const JoinEventModal: React.FC<Props> = ({
           {loading ? (
             <>
               <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
-              Submitting...
+              {t('joinModal.submitting')}
             </>
           ) : (
             <>
               <i className="bi bi-calendar2-check me-2"></i>
-              Join Game Session
+              {t('joinModal.joinGameSession')}
             </>
           )}
         </Button>

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -296,6 +296,14 @@
     "noLongerAvailable": "Event not found or no longer available"
   },
   "joinModal": {
+    "title": "Join {{hostName}}'s Game Session",
+    "loadingText": "Loading available options...",
+    "whereToPlay": "Where would you like to play?",
+    "locationHelp": "Select all locations where you can play.",
+    "whenToStart": "When would you like to start?",
+    "timeSlotHelp": "Select all time slots that work for you. {{hostName}} will choose the final time based on your availability.",
+    "submitting": "Submitting...",
+    "joinGameSession": "Join Game Session",
     "selectLocation": "Please select at least one location",
     "selectTimeSlot": "Please select at least one time slot",
     "failedToJoin": "Failed to join event",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -296,6 +296,14 @@
     "noLongerAvailable": "Evento no encontrado o ya no disponible"
   },
   "joinModal": {
+    "title": "Únete a la Sesión de Juego de {{hostName}}",
+    "loadingText": "Cargando opciones disponibles...",
+    "whereToPlay": "¿Dónde te gustaría jugar?",
+    "locationHelp": "Selecciona todas las ubicaciones donde puedes jugar.",
+    "whenToStart": "¿Cuándo te gustaría empezar?",
+    "timeSlotHelp": "Selecciona todos los horarios que te funcionan. {{hostName}} elegirá el horario final basado en tu disponibilidad.",
+    "submitting": "Enviando...",
+    "joinGameSession": "Unirse a la Sesión de Juego",
     "selectLocation": "Por favor selecciona al menos una ubicación",
     "selectTimeSlot": "Por favor selecciona al menos un horario",
     "failedToJoin": "Error al unirse al evento",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -296,6 +296,14 @@
     "noLongerAvailable": "Événement introuvable ou plus disponible"
   },
   "joinModal": {
+    "title": "Rejoindre la Session de Jeu de {{hostName}}",
+    "loadingText": "Chargement des options disponibles...",
+    "whereToPlay": "Où aimeriez-vous jouer ?",
+    "locationHelp": "Sélectionnez tous les lieux où vous pouvez jouer.",
+    "whenToStart": "Quand aimeriez-vous commencer ?",
+    "timeSlotHelp": "Sélectionnez tous les créneaux horaires qui vous conviennent. {{hostName}} choisira l'heure finale basée sur votre disponibilité.",
+    "submitting": "Envoi en cours...",
+    "joinGameSession": "Rejoindre la Session de Jeu",
     "selectLocation": "Veuillez sélectionner au moins un lieu",
     "selectTimeSlot": "Veuillez sélectionner au moins un créneau horaire",
     "failedToJoin": "Échec de rejoindre l'événement",

--- a/frontend/src/i18n/locales/pl/translation.json
+++ b/frontend/src/i18n/locales/pl/translation.json
@@ -296,6 +296,14 @@
     "noLongerAvailable": "Wydarzenia nie znaleziono lub jest niedostępne"
   },
   "joinModal": {
+    "title": "Dołącz do Sesji Gry {{hostName}}",
+    "loadingText": "Ładowanie dostępnych opcji...",
+    "whereToPlay": "Gdzie chciałbyś grać?",
+    "locationHelp": "Wybierz wszystkie lokalizacje, gdzie możesz grać.",
+    "whenToStart": "Kiedy chciałbyś zacząć?",
+    "timeSlotHelp": "Wybierz wszystkie terminy, które Ci odpowiadają. {{hostName}} wybierze ostateczny czas na podstawie Twojej dostępności.",
+    "submitting": "Wysyłanie...",
+    "joinGameSession": "Dołącz do Sesji Gry",
     "selectLocation": "Wybierz co najmniej jedną lokalizację",
     "selectTimeSlot": "Wybierz co najmniej jeden termin",
     "failedToJoin": "Nie udało się dołączyć do wydarzenia",


### PR DESCRIPTION
Localize the Join Event dialog in the frontend to support multiple languages.

This PR adds new translation keys for the modal title, loading states, section headers, help texts, button labels, and error messages, and updates the `JoinEventModal.tsx` component to use these keys with `i18next`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e18ddd4a-b2ff-470e-be49-5f4aef49a169">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e18ddd4a-b2ff-470e-be49-5f4aef49a169">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

