### PR TITLE
Fix profile completion dialog bug

### DIFF
--- a/frontend/src/components/ProfileSetup.tsx
+++ b/frontend/src/components/ProfileSetup.tsx
@@ -23,7 +23,7 @@ export const ProfileSetup: React.FC<ProfileSetupProps> = ({ onComplete }) => {
     firstName: user?.firstName || '',
     lastName: user?.lastName || '',
     ntrpLevel: '',
-    preferredCity: '',
+    city: '',
   });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -53,7 +53,7 @@ export const ProfileSetup: React.FC<ProfileSetupProps> = ({ onComplete }) => {
         if (response.profile) {
           // Profile exists, check if it's complete
           const profile = response.profile;
-          const isComplete = profile.firstName && profile.lastName && profile.ntrpLevel && profile.preferredCity;
+          const isComplete = profile.firstName && profile.lastName && profile.ntrpLevel && profile.city;
 
           if (isComplete) {
             onComplete();
@@ -67,7 +67,7 @@ export const ProfileSetup: React.FC<ProfileSetupProps> = ({ onComplete }) => {
             firstName: profile.firstName || user?.firstName || '',
             lastName: profile.lastName || user?.lastName || '',
             ntrpLevel: profile.ntrpLevel?.toString() || '',
-            preferredCity: profile.preferredCity || '',
+            city: profile.city || '',
           }));
         } else {
           // No profile exists, we'll create one
@@ -110,7 +110,7 @@ export const ProfileSetup: React.FC<ProfileSetupProps> = ({ onComplete }) => {
           firstName: formData.firstName,
           lastName: formData.lastName,
           ntrpLevel: parseFloat(formData.ntrpLevel),
-          preferredCity: formData.preferredCity,
+          city: formData.city,
         });
       } else {
         // Create new profile
@@ -118,7 +118,7 @@ export const ProfileSetup: React.FC<ProfileSetupProps> = ({ onComplete }) => {
           firstName: formData.firstName,
           lastName: formData.lastName,
           ntrpLevel: parseFloat(formData.ntrpLevel),
-          preferredCity: formData.preferredCity,
+          city: formData.city,
         });
       }
       onComplete();
@@ -214,8 +214,8 @@ export const ProfileSetup: React.FC<ProfileSetupProps> = ({ onComplete }) => {
                   <Form.Label>{t('profileSetup.fields.preferredCity')}</Form.Label>
                   <Form.Control
                     type="text"
-                    name="preferredCity"
-                    value={formData.preferredCity}
+                    name="city"
+                    value={formData.city}
                     onChange={handleChange}
                     required
                     placeholder={t('profileSetup.placeholders.preferredCity')}

--- a/frontend/src/services/mockApi.ts
+++ b/frontend/src/services/mockApi.ts
@@ -682,7 +682,7 @@ export class MockAPIClient implements APIClient {
         firstName: `User`,
         lastName: `${userId.slice(-4)}`,
         ntrpLevel: 3.0,
-        preferredCity: 'Mock City'
+        city: 'Mock City'
       }
     };
   }
@@ -697,7 +697,7 @@ export class MockAPIClient implements APIClient {
         firstName: request.firstName,
         lastName: request.lastName,
         ntrpLevel: request.ntrpLevel,
-        preferredCity: request.preferredCity
+        city: request.city
       }
     };
   }
@@ -712,7 +712,7 @@ export class MockAPIClient implements APIClient {
         firstName: request.firstName,
         lastName: request.lastName,
         ntrpLevel: request.ntrpLevel,
-        preferredCity: request.preferredCity
+        city: request.city
       }
     };
   }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -51,7 +51,7 @@ export interface UpdateProfileRequest {
   firstName: string;
   lastName: string;
   ntrpLevel: number;
-  preferredCity: string;
+  city: string;
 }
 
 export interface APIClient {

--- a/frontend/src/types/schema.d.ts
+++ b/frontend/src/types/schema.d.ts
@@ -396,7 +396,7 @@ export interface components {
             lastName?: string;
             /** Format: double */
             ntrpLevel?: number;
-            preferredCity?: string;
+            city?: string;
             userId?: string;
         };
         "ConfirmEvent-FmInput": {
@@ -416,7 +416,7 @@ export interface components {
             lastName?: string;
             /** Format: double */
             ntrpLevel?: number;
-            preferredCity?: string;
+            city?: string;
         };
         "JoinEventHandler-FmInput": {
             joinRequest: components["schemas"]["ApiJoinRequestData"];
@@ -426,7 +426,7 @@ export interface components {
             lastName?: string;
             /** Format: double */
             ntrpLevel?: number;
-            preferredCity?: string;
+            city?: string;
             userId?: string;
         };
     };


### PR DESCRIPTION
Rename `preferredCity` to `city` in frontend components and types to align with the backend API and correctly determine profile completion.

The "Complete Your Profile" dialog was incorrectly displayed because the frontend was checking for the `preferredCity` field, while the backend's profile object uses `city`. This change ensures the frontend logic correctly identifies a complete profile.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b9895c3-e42e-4215-97f2-1a7ca6729042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b9895c3-e42e-4215-97f2-1a7ca6729042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

